### PR TITLE
Check EOF after TDataSet.Next to prevent double-handling of last record

### DIFF
--- a/source/RlxRazor.pas
+++ b/source/RlxRazor.pas
@@ -1955,9 +1955,8 @@ begin
     end
     else
     begin
-      if not (TDataSet(FLoopObject).EOF) then
-        TDataSet(FLoopObject).Next
-      else
+      TDataSet(FLoopObject).Next;
+      if TDataSet(FLoopObject).EOF then
         Result := False; // done
     end;
   end;


### PR DESCRIPTION
The check for EOF has been modified so it is called directly after the call to Next.  Previously, the ForEach loop was accessing the last record in a dataset twice.
Extra unit tests have been added to cover ForEach with datasets.

Thanks

Kevin Dean